### PR TITLE
Added Github Action for deploying Docker image to Docker Hub

### DIFF
--- a/.github/workflows/dockerhub_deployment.yml
+++ b/.github/workflows/dockerhub_deployment.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Login to Docker Hub
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build and publish Docker Image
-        run: ./gradlew clean build -Pnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true -Dquarkus.container-image.group=lfenergycompas -Dquarkus.container-image.name=compas-scl-data-service -Dquarkus.container-image.push=true
+        run: ./gradlew clean build -Dquarkus-profile=publishNativeImage
         env:
           GITHUB_USERNAME: "OWNER"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dockerhub_deployment.yml
+++ b/.github/workflows/dockerhub_deployment.yml
@@ -11,23 +11,12 @@ jobs:
     name: Build and publish
     runs-on: ubuntu-latest
     steps:
-      # - name: Get release tag
-      #   id: tag_name
-      #   run: echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
       - name: Check out the repo
         uses: actions/checkout@v2
-      - name: Login to DockerHub
+      - name: Login to Docker Hub
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build and publish Docker Image
-        # env:
-        #   SOURCE_TAG: ${{ steps.tag_name.outputs.SOURCE_TAG }}
         run: ./gradlew clean build -Pnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true -Dquarkus.container-image.group=lfenergycompas -Dquarkus.container-image.name=scl-data-service -Dquarkus.container-image.push=true
         env:
           GITHUB_USERNAME: "OWNER"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@v2
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKERHUB_REPOSITORY: ivandotv/grant-server

--- a/.github/workflows/dockerhub_deployment.yml
+++ b/.github/workflows/dockerhub_deployment.yml
@@ -22,6 +22,9 @@ jobs:
         # env:
         #   SOURCE_TAG: ${{ steps.tag_name.outputs.SOURCE_TAG }}
         run: ./gradlew clean build -Pnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true -Dquarkus.container-image.group=lfenergycompas -Dquarkus.container-image.name=scl-data-service -Dquarkus.container-image.push=true
+        env:
+          GITHUB_USERNAME: "OWNER"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v2
         env:

--- a/.github/workflows/dockerhub_deployment.yml
+++ b/.github/workflows/dockerhub_deployment.yml
@@ -4,7 +4,9 @@
 
 name: Docker Hub Deployment
 
-on: push
+on:
+  release:
+    types: [released]
 
 jobs:
   push_to_registry:
@@ -16,7 +18,7 @@ jobs:
       - name: Login to Docker Hub
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build and publish Docker Image
-        run: ./gradlew clean build -Pnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true -Dquarkus.container-image.group=lfenergycompas -Dquarkus.container-image.name=scl-data-service -Dquarkus.container-image.push=true
+        run: ./gradlew clean build -Pnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true -Dquarkus.container-image.group=lfenergycompas -Dquarkus.container-image.name=compas-scl-data-service -Dquarkus.container-image.push=true
         env:
           GITHUB_USERNAME: "OWNER"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dockerhub_deployment.yml
+++ b/.github/workflows/dockerhub_deployment.yml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2021 Alliander N.V.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Docker Hub Deployment
+
+on: push
+
+jobs:
+  push_to_registry:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    steps:
+      # - name: Get release tag
+      #   id: tag_name
+      #   run: echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Login to DockerHub
+        run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Build and publish Docker Image
+        # env:
+        #   SOURCE_TAG: ${{ steps.tag_name.outputs.SOURCE_TAG }}
+        run: ./gradlew clean build -Pnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true -Dquarkus.container-image.group=lfenergycompas -Dquarkus.container-image.name=scl-data-service -Dquarkus.container-image.push=true
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v2
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKERHUB_REPOSITORY: ivandotv/grant-server

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,6 +9,7 @@ plugins {
 }
 
 dependencies {
+    implementation 'io.quarkus:quarkus-container-image-docker'
     implementation enforcedPlatform("io.quarkus:quarkus-universe-bom:${quarkusPlatformVersion}")
 
     implementation 'io.quarkus:quarkus-arc'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,6 @@ plugins {
 }
 
 dependencies {
-    implementation 'io.quarkus:quarkus-container-image-docker'
     implementation enforcedPlatform("io.quarkus:quarkus-universe-bom:${quarkusPlatformVersion}")
 
     implementation 'io.quarkus:quarkus-arc'
@@ -17,6 +16,7 @@ dependencies {
     implementation 'io.quarkus:quarkus-smallrye-openapi'
     implementation 'io.quarkus:quarkus-smallrye-health'
     implementation 'io.quarkus:quarkus-resteasy-jaxb'
+    implementation 'io.quarkus:quarkus-container-image-docker'
 
     implementation 'org.lfenergy.compas:core-commons'
     implementation project(':service')

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -5,6 +5,9 @@
 quarkus.http.cors      = false
 quarkus.http.root-path = /compas-scl-data-service/
 
+quarkus.log.level = INFO
+quarkus.log.category."org.lfenergy.compas.scl.data".level = INFO
+
 # BaseX configuration
 basex.host              = localhost
 basex.port              = 1984

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -9,3 +9,10 @@ basex.host              = localhost
 basex.port              = 1984
 basex.username          = admin
 basex.password          = admin
+
+# Properties only used for publishing a native docker image (default to Docker Hub)
+%publishNativeImage.quarkus.native.container-build=true
+%publishNativeImage.quarkus.container-image.build=true
+%publishNativeImage.quarkus.container-image.group=lfenergycompas
+%publishNativeImage.quarkus.container-image.name=compas-scl-data-service
+%publishNativeImage.quarkus.container-image.push=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,7 @@ sonarQubePluginVersion=3.2.0
 
 # Gradle logging level
 org.gradle.logging.level=INFO
+
+# Docker image properties
+quarkus.container-image.group=lfenergycompas
+quarkus.container-image.name=scl-data-service

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,3 @@ sonarQubePluginVersion=3.2.0
 
 # Gradle logging level
 org.gradle.logging.level=INFO
-
-# Docker image properties
-quarkus.container-image.group=lfenergycompas
-quarkus.container-image.name=scl-data-service

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,12 @@
-#Gradle properties
-#Sat Jun 05 22:26:32 CEST 2021
+# SPDX-FileCopyrightText: 2021 Alliander N.V.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Version Plugins and Dependencies
+jandexPluginVersion=0.9.0
 quarkusPluginVersion=1.13.4.Final
 quarkusPlatformVersion=1.13.4.Final
-org.gradle.logging.level=INFO
-jandexPluginVersion=0.9.0
 sonarQubePluginVersion=3.2.0
+
+# Gradle logging level
+org.gradle.logging.level=INFO

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,7 @@
-# SPDX-FileCopyrightText: 2021 Alliander N.V.
-#
-# SPDX-License-Identifier: Apache-2.0
-
-# Version Plugins and Dependencies
-jandexPluginVersion=0.9.0
+#Gradle properties
+#Sat Jun 05 22:26:32 CEST 2021
 quarkusPluginVersion=1.13.4.Final
 quarkusPlatformVersion=1.13.4.Final
-sonarQubePluginVersion=3.2.0
-
-# Gradle logging level
 org.gradle.logging.level=INFO
+jandexPluginVersion=0.9.0
+sonarQubePluginVersion=3.2.0


### PR DESCRIPTION
Some questions are unanswered:
- The Github Action is now triggered on every push. For the develop branch, this is probably fine (keep publishing a snapshot), but for a Master / release branch it's preferred to trigger on release like this:
```yaml
on:
  release:
    types: [published]
```
This needs to be discussed first, also see the issue about release management in the compas-architecture repository.
More info: https://dev.to/ivandotv/automate-publishing-of-your-github-repository-to-docker-hub-5872.
- A private Docker Hub account is used for storing the image. According to the LF Energy community, this is okay but I don't agree. We need a better solution for this. Until then, we can use this one.