### PR TITLE
Call to retrieve a List of SCL types

### DIFF
--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -10,6 +10,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v2
@@ -24,3 +25,4 @@ jobs:
       env:
         GITHUB_USERNAME: "OWNER"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  c

--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -25,4 +25,3 @@ jobs:
       env:
         GITHUB_USERNAME: "OWNER"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  c

--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -8,7 +8,7 @@ on: push
 
 jobs:
   build:
-
+    name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/sonarcloud_analysis.yml
+++ b/.github/workflows/sonarcloud_analysis.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+
     steps:
       - uses: actions/checkout@v2
         with:

--- a/README.md
+++ b/README.md
@@ -8,4 +8,46 @@ SPDX-License-Identifier: Apache-2.0
 [![REUSE status](https://api.reuse.software/badge/github.com/com-pas/compas-scl-data-service)](https://api.reuse.software/info/github.com/com-pas/compas-scl-data-service)
 
 # compas-scl-data-service
-Service to store and retrieve the SCL XML to a database
+
+Service to store and retrieve the SCL XML to a database.
+
+This project uses Quarkus, the Supersonic Subatomic Java Framework. If you want to learn more about Quarkus, please
+visit its website: https://quarkus.io/ .
+
+## Application depends on a running BaseX instance
+
+Check [basexhttp on DockerHub](https://hub.docker.com/r/basex/basexhttp/) for a running BaseX docker container.
+
+## Running the application in dev mode
+
+You can run your application in dev mode that enables live coding using:
+
+```
+./gradlew quarkusDev
+```
+
+## Packaging and running the application
+
+The application can be packaged using `./gradlew quarkusBuild`. It produces
+the `compas-scl-data-service-1.0-SNAPSHOT-runner.jar` file in the `build` directory. Be aware that it’s not an _
+über-jar_ as the dependencies are copied into the `build/lib` directory.
+
+The application is now runnable using `java -jar build/compas-cim-mapping-1.0-SNAPSHOT-runner.jar`.
+
+If you want to build an _über-jar_, just add the `--uber-jar` option to the command line:
+
+```
+./gradlew quarkusBuild --uber-jar
+```
+
+## Creating a native executable
+
+You can create a native executable using: `./gradlew build -Dquarkus.package.type=native`.
+
+Or, if you don't have GraalVM installed, you can run the native executable build in a container
+using: `./gradlew build -Dquarkus.package.type=native -Dquarkus.native.container-build=true`.
+
+You can then execute your native executable with: `./build/compas-scl-data-service-1.0-SNAPSHOT-runner`
+
+If you want to learn more about building native executables, please
+consult https://quarkus.io/guides/gradle-tooling#building-a-native-executable.

--- a/app/src/main/java/org/lfenergy/compas/scl/data/rest/model/Type.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/data/rest/model/Type.java
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2021 Alliander N.V.
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.lfenergy.compas.scl.data.rest.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Type {
+    @XmlElement(name = "Code")
+    private String code;
+    @XmlElement(name = "Description")
+    private String description;
+
+    public Type(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/app/src/main/java/org/lfenergy/compas/scl/data/rest/model/TypeListResponse.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/data/rest/model/TypeListResponse.java
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2021 Alliander N.V.
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.lfenergy.compas.scl.data.rest.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+@XmlRootElement(name = "TypeListResponse")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class TypeListResponse {
+    @XmlElement(name = "Type")
+    private List<Type> types = new ArrayList<>();
+
+    public void setTypes(List<Type> types) {
+        this.types = types;
+    }
+
+    public List<Type> getTypes() {
+        return types;
+    }
+}

--- a/app/src/main/java/org/lfenergy/compas/scl/data/rest/v1/CompasCommonResource.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/data/rest/v1/CompasCommonResource.java
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2021 Alliander N.V.
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.lfenergy.compas.scl.data.rest.v1;
+
+import org.lfenergy.compas.scl.data.model.SclType;
+import org.lfenergy.compas.scl.data.rest.model.Type;
+import org.lfenergy.compas.scl.data.rest.model.TypeListResponse;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/common/v1/")
+public class CompasCommonResource {
+    @GET
+    @Path("/type/list")
+    @Produces(MediaType.APPLICATION_XML)
+    public TypeListResponse list() {
+        var response = new TypeListResponse();
+        for (var sclType : SclType.values()) {
+            var responseType = new Type(sclType.name(), sclType.getDescription());
+            response.getTypes().add(responseType);
+        }
+        return response;
+    }
+}

--- a/app/src/main/java/org/lfenergy/compas/scl/data/rest/v1/CompasCommonResource.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/data/rest/v1/CompasCommonResource.java
@@ -11,6 +11,8 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 @Path("/common/v1/")
 public class CompasCommonResource {
@@ -19,10 +21,10 @@ public class CompasCommonResource {
     @Produces(MediaType.APPLICATION_XML)
     public TypeListResponse list() {
         var response = new TypeListResponse();
-        for (var sclType : SclType.values()) {
-            var responseType = new Type(sclType.name(), sclType.getDescription());
-            response.getTypes().add(responseType);
-        }
+        response.setTypes(
+                Arrays.stream(SclType.values())
+                        .map(sclType -> new Type(sclType.name(), sclType.getDescription()))
+                        .collect(Collectors.toList()));
         return response;
     }
 }

--- a/app/src/main/resources/META-INF/resources/index.html
+++ b/app/src/main/resources/META-INF/resources/index.html
@@ -138,7 +138,9 @@ SPDX-License-Identifier: Apache-2.0
         <div class="right-section">
             <h3>More info</h3>
             <ul>
-                <li><a href="/openapi-ui/index.html" class="path-link" rel="noopener">OpenAPI UI</a></code></a></li>
+                <li><a href="/compas-scl-data-service/q/swagger-ui" class="path-link" rel="noopener">
+                    OpenAPI UI
+                </a></code></a></li>
             </ul>
         </div>
     </div>

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -2,10 +2,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-quarkus.log.category."org.lfenergy.compas.scl.data".level=INFO
+quarkus.http.cors = false
+
+quarkus.log.level = INFO
+quarkus.log.category."org.lfenergy.compas.scl.data".level = INFO
+
+%dev.quarkus.http.port = 9090
+%dev.quarkus.http.cors = true
+
+%dev.quarkus.log.level = DEBUG
+%dev.quarkus.log.category."org.lfenergy.compas.scl.data".level = DEBUG
 
 # BaseX configuration
-basex.host              = localhost
-basex.port              = 1984
-basex.username          = admin
-basex.password          = admin
+basex.host      = localhost
+basex.port      = 1984
+basex.username  = admin
+basex.password  = admin

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -7,14 +7,16 @@ quarkus.http.cors = false
 quarkus.log.level = INFO
 quarkus.log.category."org.lfenergy.compas.scl.data".level = INFO
 
-%dev.quarkus.http.port = 9090
-%dev.quarkus.http.cors = true
-
-%dev.quarkus.log.level = DEBUG
-%dev.quarkus.log.category."org.lfenergy.compas.scl.data".level = DEBUG
-
-# BaseX configuration
+# BaseX Client Configuration
 basex.host      = localhost
 basex.port      = 1984
 basex.username  = admin
 basex.password  = admin
+
+# Dev Profile overrides.
+%dev.quarkus.http.port      = 9090
+%dev.quarkus.http.cors      = true
+%dev.quarkus.http.root-path = /compas-scl-data-service/
+
+%dev.quarkus.log.level = DEBUG
+%dev.quarkus.log.category."org.lfenergy.compas.scl.data".level = DEBUG

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-quarkus.http.cors = false
+quarkus.http.cors      = false
+quarkus.http.root-path = /compas-scl-data-service/
 
 quarkus.log.level = INFO
 quarkus.log.category."org.lfenergy.compas.scl.data".level = INFO
@@ -16,7 +17,6 @@ basex.password  = admin
 # Dev Profile overrides.
 %dev.quarkus.http.port      = 9090
 %dev.quarkus.http.cors      = true
-%dev.quarkus.http.root-path = /compas-scl-data-service/
 
 %dev.quarkus.log.level = DEBUG
 %dev.quarkus.log.category."org.lfenergy.compas.scl.data".level = DEBUG

--- a/app/src/test/java/org/lfenergy/compas/scl/data/rest/model/TypeListResponseTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/data/rest/model/TypeListResponseTest.java
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2021 Alliander N.V.
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.lfenergy.compas.scl.data.rest.model;
+
+class TypeListResponseTest extends AbstractPojoTester {
+    @Override
+    protected Class<?> getClassToBeTested() {
+        return TypeListResponse.class;
+    }
+}

--- a/app/src/test/java/org/lfenergy/compas/scl/data/rest/model/TypeTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/data/rest/model/TypeTest.java
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2021 Alliander N.V.
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.lfenergy.compas.scl.data.rest.model;
+
+class TypeTest extends AbstractPojoTester {
+    @Override
+    protected Class<?> getClassToBeTested() {
+        return Type.class;
+    }
+}

--- a/app/src/test/java/org/lfenergy/compas/scl/data/rest/v1/CompasCommonResourceTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/data/rest/v1/CompasCommonResourceTest.java
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2021 Alliander N.V.
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.lfenergy.compas.scl.data.rest.v1;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import org.lfenergy.compas.scl.data.model.SclType;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+@TestHTTPEndpoint(CompasCommonResource.class)
+class CompasCommonResourceTest {
+    @Test
+    void list_WhenCalled_ThenItemResponseRetrieved() {
+        var response = given()
+                .when().get("/type/list")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        var xmlPath = response.xmlPath();
+        assertEquals(SclType.values().length, xmlPath.getList("TypeListResponse.Type").size());
+    }
+}

--- a/app/src/test/java/org/lfenergy/compas/scl/data/rest/v1/CompasSclDataResourceTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/data/rest/v1/CompasSclDataResourceTest.java
@@ -7,7 +7,6 @@ import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.restassured.http.ContentType;
-import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import org.lfenergy.compas.commons.MarshallerWrapper;
 import org.lfenergy.compas.scl.SCL;
@@ -19,7 +18,6 @@ import org.lfenergy.compas.scl.data.rest.model.CreateRequest;
 import org.lfenergy.compas.scl.data.rest.model.UpdateRequest;
 import org.lfenergy.compas.scl.data.service.CompasSclDataService;
 
-import java.io.InputStream;
 import java.util.Collections;
 import java.util.UUID;
 
@@ -43,7 +41,7 @@ class CompasSclDataResourceTest {
 
         when(compasSclDataService.list(type)).thenReturn(Collections.singletonList(new Item(uuid.toString(), version)));
 
-        Response response = given()
+        var response = given()
                 .pathParam(TYPE_PATH_PARAM, type)
                 .when().get("/list")
                 .then()
@@ -65,7 +63,7 @@ class CompasSclDataResourceTest {
 
         when(compasSclDataService.listVersionsByUUID(type, uuid)).thenReturn(Collections.singletonList(new Item(uuid.toString(), version)));
 
-        Response response = given()
+        var response = given()
                 .pathParam(TYPE_PATH_PARAM, type)
                 .pathParam(ID_PATH_PARAM, uuid)
                 .when().get("/{" + ID_PATH_PARAM + "}/versions")
@@ -88,7 +86,7 @@ class CompasSclDataResourceTest {
 
         when(compasSclDataService.findByUUID(type, uuid)).thenReturn(scl);
 
-        Response response = given()
+        var response = given()
                 .pathParam(TYPE_PATH_PARAM, type)
                 .pathParam(ID_PATH_PARAM, uuid)
                 .when().get("/{" + ID_PATH_PARAM + "}")
@@ -112,7 +110,7 @@ class CompasSclDataResourceTest {
 
         when(compasSclDataService.findByUUID(type, uuid, version)).thenReturn(scl);
 
-        Response response = given()
+        var response = given()
                 .pathParam(TYPE_PATH_PARAM, type)
                 .pathParam(ID_PATH_PARAM, uuid)
                 .pathParam(VERSION_PATH_PARAM, version.toString())
@@ -136,7 +134,7 @@ class CompasSclDataResourceTest {
 
         when(compasSclDataService.findByUUID(type, uuid)).thenReturn(scl);
 
-        Response response = given()
+        var response = given()
                 .pathParam(TYPE_PATH_PARAM, type)
                 .pathParam(ID_PATH_PARAM, uuid)
                 .when().get("/{" + ID_PATH_PARAM + "}/scl")
@@ -160,7 +158,7 @@ class CompasSclDataResourceTest {
 
         when(compasSclDataService.findByUUID(type, uuid, version)).thenReturn(scl);
 
-        Response response = given()
+        var response = given()
                 .pathParam(TYPE_PATH_PARAM, type)
                 .pathParam(ID_PATH_PARAM, uuid)
                 .pathParam(VERSION_PATH_PARAM, version.toString())
@@ -189,7 +187,7 @@ class CompasSclDataResourceTest {
 
         when(compasSclDataService.create(eq(type), eq(name), any(SCL.class))).thenReturn(uuid);
 
-        Response response = given()
+        var response = given()
                 .pathParam(TYPE_PATH_PARAM, type)
                 .contentType(ContentType.XML)
                 .body(request)
@@ -265,7 +263,7 @@ class CompasSclDataResourceTest {
     }
 
     private SCL readSCL() throws Exception {
-        InputStream inputStream = getClass().getResourceAsStream("/scl/icd_import_ied_test.xml");
+        var inputStream = getClass().getResourceAsStream("/scl/icd_import_ied_test.xml");
         assert inputStream != null;
         return new MarshallerWrapper.Builder().build().unmarshall(inputStream);
     }

--- a/buildSrc/src/main/groovy/org.lfenergy.compas.scl.data.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.lfenergy.compas.scl.data.java-common-conventions.gradle
@@ -40,6 +40,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.1'
     testImplementation "org.mockito:mockito-junit-jupiter:3.+"
     testImplementation 'com.openpojo:openpojo:0.9.1'
+    testImplementation 'org.slf4j:slf4j-simple:1.7.30'
 
     // Use JUnit Jupiter Engine for testing.
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'

--- a/repository-basex/src/test/java/org/lfenergy/compas/scl/data/basex/BaseXClientFactoryTest.java
+++ b/repository-basex/src/test/java/org/lfenergy/compas/scl/data/basex/BaseXClientFactoryTest.java
@@ -3,34 +3,26 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.basex;
 
-import org.basex.BaseXServer;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.lfenergy.compas.scl.data.basex.BaseXServerUtil.*;
+import static org.lfenergy.compas.scl.data.basex.BaseXServerUtil.createClientFactory;
 
+@ExtendWith({BaseXServerJUnitExtension.class})
 class BaseXClientFactoryTest {
-    private static BaseXServer server;
     private static BaseXClientFactory factory;
 
     @BeforeAll
-    static void beforeAll() throws IOException {
-        int portNumber = getFreePortNumber();
-        server = createServer(portNumber);
-        factory = createClientFactory(portNumber);
+    static void beforeAll() {
+        factory = createClientFactory(BaseXServerJUnitExtension.getPortNumber());
     }
 
     @Test
     void createClient_WhenCalled_ThenReturnClient() throws IOException {
         assertNotNull(factory.createClient());
-    }
-
-    @AfterAll
-    static void afterAll() {
-        server.stop();
     }
 }

--- a/repository-basex/src/test/java/org/lfenergy/compas/scl/data/basex/BaseXServerJUnitExtension.java
+++ b/repository-basex/src/test/java/org/lfenergy/compas/scl/data/basex/BaseXServerJUnitExtension.java
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2021 Alliander N.V.
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.lfenergy.compas.scl.data.basex;
+
+import org.basex.BaseXServer;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.GLOBAL;
+import static org.lfenergy.compas.scl.data.basex.BaseXServerUtil.createServer;
+import static org.lfenergy.compas.scl.data.basex.BaseXServerUtil.getFreePortNumber;
+
+/**
+ * JUnit extension to start a BaseX Server. This server should only be started and stopped once for all
+ * JUnit Tests.
+ */
+public class BaseXServerJUnitExtension implements BeforeAllCallback, ExtensionContext.Store.CloseableResource {
+    private static BaseXServer server;
+    private static int portNumber;
+
+    // Gate keeper to prevent multiple Threads within the same routine
+    private final static Lock lock = new ReentrantLock();
+
+    @Override
+    public void beforeAll(final ExtensionContext context) throws Exception {
+        // lock the access so only one Thread has access to it
+        lock.lock();
+        if (server == null) {
+            portNumber = getFreePortNumber();
+            server = createServer(portNumber);
+
+            // The following line registers a callback hook when the root test context is shut down
+            context.getRoot().getStore(GLOBAL).put("BaseXServerExtension", this);
+        }
+        // free the access
+        lock.unlock();
+    }
+
+    @Override
+    public void close() {
+        server.stop();
+    }
+
+    public static int getPortNumber() {
+        return portNumber;
+    }
+}

--- a/repository-basex/src/test/java/org/lfenergy/compas/scl/data/repository/CompasSclDataBaseXRepositoryTest.java
+++ b/repository-basex/src/test/java/org/lfenergy/compas/scl/data/repository/CompasSclDataBaseXRepositoryTest.java
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.repository;
 
-import org.basex.BaseXServer;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,6 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.lfenergy.compas.commons.MarshallerWrapper;
 import org.lfenergy.compas.scl.SCL;
 import org.lfenergy.compas.scl.data.basex.BaseXClientFactory;
+import org.lfenergy.compas.scl.data.basex.BaseXServerJUnitExtension;
 import org.lfenergy.compas.scl.data.model.ChangeSetType;
 import org.lfenergy.compas.scl.data.model.SclType;
 import org.lfenergy.compas.scl.data.model.Version;
@@ -20,31 +19,23 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.lfenergy.compas.scl.data.basex.BaseXServerUtil.*;
+import static org.lfenergy.compas.scl.data.basex.BaseXServerUtil.createClientFactory;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, BaseXServerJUnitExtension.class})
 class CompasSclDataBaseXRepositoryTest {
     private static final SclType TYPE = SclType.SCD;
-    private static BaseXServer server;
     private static BaseXClientFactory factory;
     private CompasSclDataBaseXRepository repository;
 
     @BeforeAll
-    static void beforeAll() throws Exception {
-        var portNumber = getFreePortNumber();
-        server = createServer(portNumber);
-        factory = createClientFactory(portNumber);
+    static void beforeAll() {
+        factory = createClientFactory(BaseXServerJUnitExtension.getPortNumber());
     }
 
     @BeforeEach
     void beforeEach() throws Exception {
         factory.createClient().executeXQuery("db:create('" + TYPE + "')");
         repository = new CompasSclDataBaseXRepository(factory);
-    }
-
-    @AfterAll
-    static void afterAll() {
-        server.stop();
     }
 
     @Test

--- a/repository/src/main/java/org/lfenergy/compas/scl/data/model/SclType.java
+++ b/repository/src/main/java/org/lfenergy/compas/scl/data/model/SclType.java
@@ -9,7 +9,9 @@ public enum SclType {
     IID("IED Instance Description"),
     ICD("IED Capability Description"),
     SCD("Substation Configuration Description"),
-    CID("Configured IED Description");
+    CID("Configured IED Description"),
+    SED("System Exchange Description"),
+    ISD("IED Specification Description");
 
     private final String description;
 


### PR DESCRIPTION
For the OpenSCD Plugin we needed a list of supported Types by the SCL Data Service. 
This REST Call is added to the SCL Data Service.

Also change the way BaseX Server is started for Unittests, hopefully this won't hang the build anymore.