### PR TITLE
Configure nicer namespace prefixes.

### DIFF
--- a/app/src/main/java/org/lfenergy/compas/scl/data/rest/model/package-info.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/data/rest/model/package-info.java
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2021 Alliander N.V.
+//
+// SPDX-License-Identifier: Apache-2.0
+@XmlSchema(
+        namespace = "https://www.lfenergy.org/compas/SclDataService",
+        xmlns = {
+                @XmlNs(prefix = "scl", namespaceURI = "http://www.iec.ch/61850/2003/SCL"),
+                @XmlNs(prefix = "compas", namespaceURI = "https://www.lfenergy.org/compas/v1"),
+                @XmlNs(prefix = "sds", namespaceURI = "https://www.lfenergy.org/compas/SclDataService")
+        })
+package org.lfenergy.compas.scl.data.rest.model;
+
+import javax.xml.bind.annotation.XmlNs;
+import javax.xml.bind.annotation.XmlSchema;

--- a/app/src/main/java/org/lfenergy/compas/scl/data/rest/v1/CompasSclDataResource.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/data/rest/v1/CompasSclDataResource.java
@@ -6,7 +6,6 @@ package org.lfenergy.compas.scl.data.rest.v1;
 import org.lfenergy.compas.scl.SCL;
 import org.lfenergy.compas.scl.data.model.SclType;
 import org.lfenergy.compas.scl.data.model.Version;
-import org.lfenergy.compas.scl.data.rest.Constants;
 import org.lfenergy.compas.scl.data.rest.model.*;
 import org.lfenergy.compas.scl.data.service.CompasSclDataService;
 
@@ -71,7 +70,7 @@ public class CompasSclDataResource {
     @Produces(MediaType.APPLICATION_XML)
     public GetResponse findByUUIDAndVersion(@PathParam(TYPE_PATH_PARAM) SclType type,
                                             @PathParam(ID_PATH_PARAM) UUID id,
-                                            @PathParam(Constants.VERSION_PATH_PARAM) Version version) {
+                                            @PathParam(VERSION_PATH_PARAM) Version version) {
         var response = new GetResponse();
         response.setScl(compasSclDataService.findByUUID(type, id, version));
         return response;
@@ -90,7 +89,7 @@ public class CompasSclDataResource {
     @Produces(MediaType.APPLICATION_XML)
     public SCL findRawSCLByUUIDAndVersion(@PathParam(TYPE_PATH_PARAM) SclType type,
                                           @PathParam(ID_PATH_PARAM) UUID id,
-                                          @PathParam(Constants.VERSION_PATH_PARAM) Version version) {
+                                          @PathParam(VERSION_PATH_PARAM) Version version) {
         return compasSclDataService.findByUUID(type, id, version);
     }
 
@@ -117,7 +116,7 @@ public class CompasSclDataResource {
     @Produces(MediaType.APPLICATION_XML)
     public void deleteVersion(@PathParam(TYPE_PATH_PARAM) SclType type,
                               @PathParam(ID_PATH_PARAM) UUID id,
-                              @PathParam(Constants.VERSION_PATH_PARAM) Version version) {
+                              @PathParam(VERSION_PATH_PARAM) Version version) {
         compasSclDataService.delete(type, id, version);
     }
 }


### PR DESCRIPTION
Some small changes to replace namespace prefixes like "ns2", "ns3" with better names like "scl", "compas" en "sds".
Last one is the namespace for all calles from de SCL Data Service.