### PR TITLE
fix: Remove custom set version steps

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,13 +33,6 @@ jobs:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashFiles('**/Dockerfile') }}
 
-      - name: Extract tag name
-        if: ${{ steps.release.outputs.release_created }}
-        id: extract_tagname
-        shell: bash
-        # Extract the tag name from the git reference, value of GITHUB_REF will be something like refs/tags/<tag_name>.
-        run: echo "##[set-output name=tagname;]$(echo ${GITHUB_REF##*/})"
-
       - name: Set up JDK 17
         if: ${{ steps.release.outputs.release_created }}
         uses: actions/setup-java@v4
@@ -64,11 +57,6 @@ jobs:
         with:
           output_file: custom_maven_settings.xml
           servers: '[{ "id": "github-packages-compas", "username": "OWNER", "password": "${{ secrets.GITHUB_TOKEN }}" }]'
-      - name: Set version with Maven
-        if: ${{ steps.release.outputs.release_created }}
-        run: ./mvnw -B versions:set -DprocessAllModules=true -DnewVersion=${{ steps.extract_tagname.outputs.tagname }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy with Maven to GitHub Packages and Docker Hub
         if: ${{ steps.release.outputs.release_created }}
         run: ./mvnw -B -s custom_maven_settings.xml -Pjvm-image,release clean deploy


### PR DESCRIPTION
With the move to release please the git commit is checked out as branch instead of a detached commit by tag, so the github ref will be the main branch.

Instead of trying to read the version number from the github ref, release please sets the version in the `pom.xml` files correctly before releasing, so there is no need to have an extra step to set the version.