### PR TITLE
Delete assigned resource must return HTTP status code 409 Conflict

### DIFF
--- a/app/src/main/java/org/lfenergy/compas/scl/data/rest/exception/CompasAssignedLocationExceptionHandler.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/data/rest/exception/CompasAssignedLocationExceptionHandler.java
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.lfenergy.compas.scl.data.rest.exception;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import org.lfenergy.compas.core.commons.model.ErrorResponse;
+import org.lfenergy.compas.scl.data.exception.CompasAssignedLocationException;
+
+@Provider
+public class CompasAssignedLocationExceptionHandler implements ExceptionMapper<CompasAssignedLocationException> {
+
+    @Override
+    public Response toResponse(CompasAssignedLocationException exception) {
+        var response = new ErrorResponse();
+        response.addErrorMessage(exception.getErrorCode(), exception.getMessage());
+        return Response.status(Response.Status.CONFLICT).entity(response).build();
+    }
+}

--- a/app/src/test/java/org/lfenergy/compas/scl/data/rest/exception/CompasAssignedLocationExceptionHandlerTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/data/rest/exception/CompasAssignedLocationExceptionHandlerTest.java
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.lfenergy.compas.scl.data.rest.exception;
+
+import org.junit.jupiter.api.Test;
+import org.lfenergy.compas.core.commons.model.ErrorResponse;
+import org.lfenergy.compas.scl.data.exception.CompasAssignedLocationException;
+
+import static jakarta.ws.rs.core.Response.Status.CONFLICT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class CompasAssignedLocationExceptionHandlerTest {
+
+    @Test
+    void toResponse_WhenCalledWithCompasAssignedLocationException_ThenConflictReturnedWithBody() {
+        var exception = new CompasAssignedLocationException("Location is assigned to a SCL file.");
+        var handler = new CompasAssignedLocationExceptionHandler();
+
+        var result = handler.toResponse(exception);
+        assertEquals(CONFLICT.getStatusCode(), result.getStatus());
+        var errorMessage = ((ErrorResponse) result.getEntity()).getErrorMessages().get(0);
+        assertEquals(exception.getErrorCode(), errorMessage.getCode());
+        assertEquals(exception.getMessage(), errorMessage.getMessage());
+        assertNull(errorMessage.getProperty());
+    }
+}

--- a/app/src/test/java/org/lfenergy/compas/scl/data/rest/v1/CompasLocationsResourceTest.java
+++ b/app/src/test/java/org/lfenergy/compas/scl/data/rest/v1/CompasLocationsResourceTest.java
@@ -5,7 +5,9 @@ package org.lfenergy.compas.scl.data.rest.v1;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.lfenergy.compas.scl.data.exception.CompasAssignedLocationException;
 import org.lfenergy.compas.scl.data.rest.api.locations.Location;
+import org.lfenergy.compas.scl.data.rest.exception.CompasAssignedLocationExceptionHandler;
 import org.lfenergy.compas.scl.data.service.LocationsService;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -14,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.UUID;
 
+import static jakarta.ws.rs.core.Response.Status.CONFLICT;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 

--- a/repository/src/main/java/org/lfenergy/compas/scl/data/exception/CompasAssignedLocationException.java
+++ b/repository/src/main/java/org/lfenergy/compas/scl/data/exception/CompasAssignedLocationException.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 BearingPoint GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.data.exception;
 
 import org.lfenergy.compas.core.commons.exception.CompasException;

--- a/repository/src/main/java/org/lfenergy/compas/scl/data/exception/CompasAssignedLocationException.java
+++ b/repository/src/main/java/org/lfenergy/compas/scl/data/exception/CompasAssignedLocationException.java
@@ -1,0 +1,12 @@
+package org.lfenergy.compas.scl.data.exception;
+
+import org.lfenergy.compas.core.commons.exception.CompasException;
+
+import static org.lfenergy.compas.scl.data.exception.CompasSclDataServiceErrorCode.INVALID_INPUT_ERROR_CODE;
+
+public class CompasAssignedLocationException extends CompasException {
+
+    public CompasAssignedLocationException(String message) {
+        super(INVALID_INPUT_ERROR_CODE, message);
+    }
+}

--- a/service/src/main/java/org/lfenergy/compas/scl/data/service/LocationsService.java
+++ b/service/src/main/java/org/lfenergy/compas/scl/data/service/LocationsService.java
@@ -6,6 +6,7 @@ package org.lfenergy.compas.scl.data.service;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import org.lfenergy.compas.scl.data.exception.CompasAssignedLocationException;
 import org.lfenergy.compas.scl.data.exception.CompasNoDataFoundException;
 import org.lfenergy.compas.scl.data.exception.CompasSclDataServiceException;
 import org.lfenergy.compas.scl.data.repository.LocationRepository;
@@ -72,8 +73,8 @@ public class LocationsService {
             .orElseThrow(() -> new CompasNoDataFoundException(
                 ERR_MSG_LOCATION_NOT_FOUND + locationId));
         if (entity.assignedResources > 0) {
-            throw new CompasSclDataServiceException(INVALID_INPUT_ERROR_CODE,
-                "Deletion not allowed, location has " + entity.assignedResources + " assigned resources: " + locationId);
+            throw new CompasAssignedLocationException(
+                "Deletion not allowed, location " + locationId + " has " + entity.assignedResources + " assigned resources");
         }
         locationRepository.delete(entity);
     }

--- a/service/src/test/java/org/lfenergy/compas/scl/data/service/LocationsServiceTest.java
+++ b/service/src/test/java/org/lfenergy/compas/scl/data/service/LocationsServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.lfenergy.compas.scl.data.entities.Location;
+import org.lfenergy.compas.scl.data.exception.CompasAssignedLocationException;
 import org.lfenergy.compas.scl.data.exception.CompasNoDataFoundException;
 import org.lfenergy.compas.scl.data.exception.CompasSclDataServiceException;
 import org.lfenergy.compas.scl.data.repository.HistorizedSclFileRepository;
@@ -174,7 +175,7 @@ class LocationsServiceTest {
         var entity = buildEntity(id, "LOC_A", "Location A", "desc", 3);
         when(locationRepository.findByIdOptional(id)).thenReturn(Optional.of(entity));
 
-        assertThrows(CompasSclDataServiceException.class,
+        assertThrows(CompasAssignedLocationException.class,
                 () -> locationsService.deleteLocation(id));
         verify(locationRepository, never()).delete(any());
     }


### PR DESCRIPTION
**Changes Made:**

* Added the new exception class `CompasAssignedLocationException` for cases when a location with assigned resources is attempted to be deleted.
* Updated `LocationsService.deleteLocation` to throw `CompasAssignedLocationException` instead of the more generic `CompasSclDataServiceException` when deletion is not allowed.
* Introduced `CompasAssignedLocationExceptionHandler` to map `CompasAssignedLocationException` to a 409 Conflict HTTP response with a structured error body.

**Testing Updates:**

* Added a unit test for `CompasAssignedLocationExceptionHandler` to verify correct error response mapping.
* Updated service and resource tests to expect and use `CompasAssignedLocationException` instead of the previous exception. 